### PR TITLE
Additional menu field meta actions for theme developers

### DIFF
--- a/includes/picker.php
+++ b/includes/picker.php
@@ -111,6 +111,18 @@ final class Menu_Icons_Picker {
 		$meta          = Menu_Icons_Meta::get( $item->ID, $menu_settings );
 		$fields        = self::_get_menu_item_fields( $meta );
 		?>
+            <?php
+            /**
+             * Allow plugins/themes to inject HTML before icon field
+             *
+             * @param object $item  Menu item data object.
+             * @param int    $depth Nav menu depth.
+             * @param array  $args  Menu item args.
+             * @param int    $id    Nav menu ID.
+             *
+             */
+            do_action( 'menu_icons_before_field_icon', $item, $depth, $args, $id );
+            ?>
 			<div class="field-icon description-wide menu-icons-wrap" data-id="<?php echo json_encode( $item->ID ); ?>">
 				<?php
 					/**
@@ -158,6 +170,18 @@ final class Menu_Icons_Picker {
 					do_action( 'menu_icons_after_fields', $item, $depth, $args, $id );
 				?>
 			</div>
+            <?php
+            /**
+             * Allow plugins/themes to inject HTML after icon field
+             *
+             * @param object $item  Menu item data object.
+             * @param int    $depth Nav menu depth.
+             * @param array  $args  Menu item args.
+             * @param int    $id    Nav menu ID.
+             *
+             */
+            do_action( 'menu_icons_after_field_icon', $item, $depth, $args, $id );
+            ?>
 		<?php
 	}
 


### PR DESCRIPTION
We are using the plugin for a custom theme which already was using an admin walker menu. After activating your plugin our themes meta fields was no longer displayed. I had a look and it seems that having additional actions while using your problem would solve our issues.
I tried adding meta-data to existing actions but as they are inside the field element checkboxes and radio etc is  prevented from being checked. 

Using something like this to hook into the plugin with:
```
/**
 * Using the hook from menu-icons plugin to inject our custom menu meta.
 * Allow plugins/themes to inject HTML after menu icons' fields
 *
 * @param object $item Menu item data object.
 * @param int $depth Nav menu depth.
 * @param array $args Menu item args.
 * @param int $id Nav menu ID.
 *
 */
add_action( 'menu_icons_after_fields', function ( $item, $depth, $args, $id ) {
	$meta   = get_post_meta( $id, false, true );
	$hide   = ! empty( $meta['_menu_item_title-hide'][0] ) ? $meta['_menu_item_title-hide'][0] : '';
	$strong = ! empty( $meta['_menu_item_title-strong'][0] ) ? $meta['_menu_item_title-strong'][0] : '';
	?>
    <p class="field-link-title-hide description">
        <label for="edit-menu-item-title-hide-<?php echo $id; ?>">
			<?php _e( 'Hide title', THEME_TEXTDOMAIN ); ?><br>
            <input
                    type="checkbox"
                    id="edit-menu-item-title-hide-<?php echo $id; ?>"
                    class="widefat edit-menu-item-title-hide"
                    name="menu-item-title-hide[<?php echo $id; ?>]"
                    value="title-hide" <?php checked( 'title-hide', $hide ); ?>>
        </label>
    </p>
    <p class="field-link-title-strong description">
        <label for="edit-menu-item-title-strong-<?php echo $id; ?>">
			<?php _e( 'Strong title', THEME_TEXTDOMAIN ); ?><br>
            <input
                    type="checkbox"
                    id="edit-menu-item-title-strong-<?php echo $id; ?>"
                    class="widefat edit-menu-item-title-strong"
                    name="menu-item-title-strong[<?php echo $id; ?>]"
                    value="title-strong" <?php checked( 'title-strong', $strong ); ?> onclick="this.toggle()">
        </label>
    </p>
    <p class="field-link-toggle description">
        <label for="edit-menu-item-toggle-<?php echo $id; ?>">
			<?php _e( 'Strong title', THEME_TEXTDOMAIN ); ?><br>
            <input
                    type="checkbox"
                    id="edit-menu-item-toggle-<?php echo $id; ?>"
                    class="widefat edit-menu-item-toggle"
                    name="menu-item-toggle[<?php echo $id; ?>]"
                    value="title-strong" <?php checked( 'toggle', $strong ); ?> onclick="this.toggle()">
        </label>
    </p>
	<?php
}, 0, 4 );

```