### PR TITLE
Prevent potential fatal error: Make sure $theme->parent() didn't return false for any odd reason

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -690,7 +690,7 @@ final class Menu_Icons_Settings {
 		$menu_current_theme = '';
 		$theme              = wp_get_theme();
 		if ( ! empty( $theme ) ) {
-			if ( is_child_theme() ) {
+			if ( is_child_theme() && $theme->parent() ) {
 				$menu_current_theme = $theme->parent()->get( 'Name' );
 			} else {
 				$menu_current_theme = $theme->get( 'Name' );


### PR DESCRIPTION
It appears some theme setups can become misconfigured where is_child_theme() returns true while wp_get_theme()->parent() returns false. This is just a quick added measure to prevent a potentially fatal error where it then tries to run get() on a false return.

I had initially found someone else with this same issue and posted a response here: https://wordpress.org/support/topic/debug-error-33/