### PR TITLE
fix: add filter for promotions and improved readme

### DIFF
--- a/menu-icons.php
+++ b/menu-icons.php
@@ -103,9 +103,14 @@ final class Menu_Icons {
 		add_action( 'admin_action_menu_icon_hide_notice', array( __CLASS__, 'wp_menu_icons_dismiss_dashboard_notice' ) );
 
 		add_filter(
-			'menu_icons_load_promotions',
+			'wp_menu_icons_load_promotions',
 			function() {
 				return array( 'otter' );
+			}
+		);
+		add_filter(
+			'wp_menu_icons_dissallowed_promotions', function () {
+				return array( 'om-editor', 'om-image-block' );
 			}
 		);
 	}

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,10 @@ Menu icons works with most of the themes out there, especially with popular ones
 
 Development of this plugin is done on [GitHub](https://github.com/codeinwp/wp-menu-icons). **Pull requests welcome**. Please see [issues reported](https://github.com/codeinwp/wp-menu-icons/issues) there before going to the plugin forum.
 
+All the code and sources is publicly available on [GitHub/wp-menu-icons](https://github.com/codeinwp/wp-menu-icons) for this plugin and
+for the [SDK](https://github.com/Codeinwp/themeisle-sdk).
+
+
 ## If you like this plugin, then consider checking out our other projects: ##
 
 [CodeinWP Blog](https://www.codeinwp.com/blog/) – Designer's Guide To WordPress


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
After merging the SDK changes introduced here: https://github.com/Codeinwp/themeisle-sdk/pull/217
We can use the filter here to disallow specific promotions from running.

Improved the Readme to link back to the sources of the plugin and of the SDK.

UnitTest is provided for the SDK changes. https://github.com/Codeinwp/themeisle-sdk/pull/217

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
To these changes, you need:
1. To use the linked SDK build
2. Set the install option to an older date `wp option update wp_menu_icons_install 1685187068`
3. Add a page with 2 or more images and publish it.
 
How to test:
1. Check that the promotion is no longer visible on the image block when 2 or more images are being added to a published page. Check this after publishing the page with the images, it should be visible during edit.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes  Codeinwp/themeisle#1634.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
