### PR TITLE
Removed dashboard notice when neve is activated

### DIFF
--- a/menu-icons.php
+++ b/menu-icons.php
@@ -196,6 +196,10 @@ final class Menu_Icons {
 	 * Render dashboard notice.
 	 */
 	public static function _wp_menu_icons_dashboard_notice() {
+		$theme = get_template();
+		if ( 'neve' === $theme ) {
+			return;
+		}
 		$show_notice = true;
 		if ( ! empty( get_option( self::DISMISS_NOTICE, false ) ) ) {
 			$show_notice = false;


### PR DESCRIPTION
### Summary
I've removed the notice from the dashboard if neve theme is activated.

## Check before Pull Request is ready:

* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #287
