### PR TITLE
feat: add Black Friday integration

### DIFF
--- a/includes/library/font-awesome/font-awesome.php
+++ b/includes/library/font-awesome/font-awesome.php
@@ -113,7 +113,7 @@ final class Menu_Icons_Font_Awesome {
 			</div>
 			</div>
 			<a class="check" href="#" title="%s"><div class="media-modal-icon"></div></a>',
-				esc_attr__( 'Deselect', 'icon-picker' )
+				esc_attr__( 'Deselect', 'menu-icons' )
 			),
 		);
 

--- a/includes/library/form-fields.php
+++ b/includes/library/form-fields.php
@@ -149,6 +149,7 @@ abstract class Kucrut_Form_Field {
 		) {
 			trigger_error(
 				sprintf(
+					// translators: %1$s - the name of the class, %2$s - the type of the field.
 					esc_html__( '%1$s: Type %2$s is not supported, reverting to text.', 'menu-icons' ),
 					__CLASS__,
 					esc_html( $field['type'] )

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -473,6 +473,7 @@ final class Menu_Icons_Settings {
 				'id'          => $menu_key,
 				'title'       => __( 'Current Menu', 'menu-icons' ),
 				'description' => sprintf(
+					// translators: %s - the name of the menu.
 					__( '"%s" menu settings', 'menu-icons' ),
 					apply_filters( 'single_term_title', $menu_term->name )
 				),
@@ -770,6 +771,7 @@ final class Menu_Icons_Settings {
 					'all'          => __( 'All', 'menu-icons' ),
 					'preview'      => __( 'Preview', 'menu-icons' ),
 					'settingsInfo' => sprintf(
+						// translators: %2$s - a link to the Customizer with the label `the customizer`.
 						'<div> %1$s <p>' . esc_html__( 'Please note that the actual look of the icons on the front-end will also be affected by the style of your active theme. You can add your own CSS using %2$s.', 'menu-icons' ) . '</p></div>',
 						$box_data,
 						sprintf(

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -113,6 +113,8 @@ final class Menu_Icons {
 				return array( 'om-editor', 'om-image-block' );
 			}
 		);
+
+		add_filter( 'themeisle_sdk_blackfriday_data', array( __CLASS__, 'add_black_friday_data' ) );
 	}
 
 
@@ -254,6 +256,33 @@ final class Menu_Icons {
 			<a href="<?php echo esc_url( $action_url ); ?>" class="notice-dismiss"></a>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Add Black Friday data.
+	 *
+	 * @param array $configs The configuration array for the loaded products.
+	 *
+	 * @return array
+	 */
+	public static function add_black_friday_data( $configs ) {
+		$config = $configs['default'];
+		$product_slug = basename(dirname(__FILE__));
+
+		// translators: %1$s - plugin name, %2$s - HTML tag, %3$s - discount, %4$s - HTML tag, %5$s - company name.
+		$message_template = __( 'Brought to you by the team behind %1$s— our biggest sale of the year is here: %2$sup to %3$s OFF%4$s on premium products from %5$s! Limited-time only.', 'menu-icons' );
+
+		$config['message']  = sprintf( $message_template, 'Menu Icons', '<strong>', '70%', '</strong>', '<strong>Themeisle</strong>' );
+		$config['sale_url'] = add_query_arg(
+			array(
+				'utm_term' => 'free',
+			),
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/all-bf', 'bfcm', 'menu-icons' ) )
+		);
+
+		$configs[ $product_slug ] = $config;
+
+		return $configs;
 	}
 }
 add_action( 'plugins_loaded', array( 'Menu_Icons', '_load' ) );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,15 +10,16 @@
 	<exclude-pattern>lib/*</exclude-pattern>
 	<exclude-pattern>tests/*</exclude-pattern>
 
-	<arg name="extensions" value="php"/>
-	<arg value="sp"/>
+	<arg name="extensions" value="php" />
+	<arg value="sp" />
 	<arg name="basepath" value="./" />
-	<arg name="parallel" value="20"/>
+	<arg name="parallel" value="20" />
 
 
 	<rule ref="WordPress-Core">
 		<exclude name="Squiz.Commenting" />
-		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceBeforeCloseParenthesis" />
+		<exclude
+			name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceBeforeCloseParenthesis" />
 		<exclude name="Squiz.PHP.EmbeddedPhp" />
 		<exclude name="Generic.Commenting" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
@@ -43,13 +44,19 @@
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Arrays.ArrayDeclarationSpacing" />
 		<exclude name="Squiz.PHP.CommentedOutCode" />
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 	</rule>
 	<rule ref="WordPress-Docs">
 
 	</rule>
-	<config name="testVersion" value="5.6-"/>
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="menu-icons" />
+			</property>
+		</properties>
+	</rule>
+	<config name="testVersion" value="5.6-" />
 	<rule ref="PHPCompatibilityWP">
 	</rule>
 	<rule ref="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add Black Friday integration.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![CleanShot 2025-05-22 at 17 01 58@2x](https://github.com/user-attachments/assets/2e3e277e-7381-4fed-beda-9dd85936e38d)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Alter the date to fall into the Black Friday sales period.

You can install [this plugin](https://github.com/Soare-Robert-Daniel/test-black-friday) or you can use this hook to modify the date:

```php
add_filter(
	'themeisle_sdk_current_date',
	function() {
		return new DateTime( '2025-11-26' );
	}
);
```

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
