### PR TITLE
refactor: change Black Friday labels to Neve promotion

### DIFF
--- a/menu-icons.php
+++ b/menu-icons.php
@@ -273,13 +273,14 @@ final class Menu_Icons {
 			return $configs;
 		}
 
-		$config['message']  = __( 'You use Menu Icons. Get more menu control with Neve Pro: advanced header builder, sticky navigation, custom layouts. Built by the same team.', 'menu-icons' );
+		// translators: 1. Number of free licenses, 2. The price of the product.
+		$config['message'] = sprintf( __( 'You\'re using Menu Icons, and the team behind it is celebrating Black Friday by giving away %1$s licences of Neve Pro. A premium WordPress theme worth %2$s, packed with starter sites, a header builder, and WooCommerce layouts. Claim yours before they run out.', 'menu-icons' ), 100, '$69' );
 		$config['cta_label'] = __( 'Get Neve Pro free', 'menu-icons' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',
 			),
-			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-bf', 'bfcm', 'menu-icons' ) )
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-claim-bf', 'bfcm', 'menu-icons' ) )
 		);
 
 		$configs[ $product_slug ] = $config;

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -269,15 +269,13 @@ final class Menu_Icons {
 		$config = $configs['default'];
 		$product_slug = basename(dirname(__FILE__));
 
-		// translators: %1$s - plugin name, %2$s - HTML tag, %3$s - discount, %4$s - HTML tag, %5$s - company name.
-		$message_template = __( 'Brought to you by the team behind %1$s— our biggest sale of the year is here: %2$sup to %3$s OFF%4$s on premium products from %5$s! Limited-time only.', 'menu-icons' );
-
-		$config['message']  = sprintf( $message_template, 'Menu Icons', '<strong>', '70%', '</strong>', '<strong>Themeisle</strong>' );
+		$config['message']  = __( 'You use Menu Icons. Get more menu control with Neve Pro: advanced header builder, sticky navigation, custom layouts. Built by the same team.', 'menu-icons' );
+		$config['cta_label'] = __( 'Get Neve Pro free', 'menu-icons' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',
 			),
-			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/all-bf', 'bfcm', 'menu-icons' ) )
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-bf', 'bfcm', 'menu-icons' ) )
 		);
 
 		$configs[ $product_slug ] = $config;

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -276,6 +276,7 @@ final class Menu_Icons {
 		// translators: 1. Number of free licenses, 2. The price of the product.
 		$config['message'] = sprintf( __( 'You\'re using Menu Icons, and the team behind it is celebrating Black Friday by giving away %1$s licences of Neve Pro. A premium WordPress theme worth %2$s, packed with starter sites, a header builder, and WooCommerce layouts. Claim yours before they run out.', 'menu-icons' ), 100, '$69' );
 		$config['cta_label'] = __( 'Get Neve Pro free', 'menu-icons' );
+		$config['plugin_meta_message'] = __( 'Black Friday Sale - Get Neve Pro free', 'menu-icons' );
 		$config['sale_url'] = add_query_arg(
 			array(
 				'utm_term' => 'free',

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -269,6 +269,10 @@ final class Menu_Icons {
 		$config = $configs['default'];
 		$product_slug = basename(dirname(__FILE__));
 
+		if ( defined( 'NEVE_VERSION' ) ) {
+			return $configs;
+		}
+
 		$config['message']  = __( 'You use Menu Icons. Get more menu control with Neve Pro: advanced header builder, sticky navigation, custom layouts. Built by the same team.', 'menu-icons' );
 		$config['cta_label'] = __( 'Get Neve Pro free', 'menu-icons' );
 		$config['sale_url'] = add_query_arg(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Add the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854
- Complete the Formbricks integration

### Screenshots <!-- if applicable -->

<img width="4676" height="190" alt="CleanShot 2026-04-09 at 17 08 36@2x" src="https://github.com/user-attachments/assets/9a588f2f-ec2d-4afe-9f59-f51168ec8fbc" />
<img width="4732" height="236" alt="CleanShot 2026-04-09 at 17 08 42@2x" src="https://github.com/user-attachments/assets/a8cec7c7-d49d-4e07-a4ee-df5d28bd4150" />



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Use this SDK version: https://github.com/Codeinwp/themeisle-sdk-main/pull/309
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1854
<!-- Should look like this: `Closes #1, #2, #3.` . -->
