### PR TITLE
Add WordPress Plugin Check action

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -21,9 +21,21 @@ jobs:
       - uses: wordpress/plugin-check-action@v1
         id: plugin-check
         with:
-          categories: plugin_repo,security,performance,general
-          ignore-warnings: false
-          ignore-errors: false
+          categories: plugin_repo,security,performance
+          exclude-directories: |
+            tests
+            bin
+            .github
+          ignore-codes: |
+            WordPress.WP.I18n.TextDomainMismatch
+            textdomain_mismatch
+            hidden_files
+            WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+            WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
+            WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+            WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+            WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+          include-experimental: false
 
       - name: Plugin Check Summary
         if: always()

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-dev --optimize-autoloader
 
-      - uses: wordpress/plugin-check-action@v1.1.5
+      - uses: wordpress/plugin-check-action@v1
         id: plugin-check
         with:
           categories: plugin_repo,security,performance,general

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-dev --optimize-autoloader
 
-      - uses: wordpress/plugin-check-action@v1
+      - uses: wordpress/plugin-check-action@v1.1.5
         id: plugin-check
         with:
           categories: plugin_repo,security,performance,general

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -38,6 +38,7 @@ jobs:
             WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
             WordPress.WP.EnqueuedResourceParameters.MissingVersion
           include-experimental: true
+          repo-token: ''
 
       - name: Plugin Check Summary
         if: always()

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,22 @@
+name: WordPress Plugin Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plugin-check:
+    name: WordPress.org Guidelines Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: wordpress/plugin-check-action@v1
+        with:
+          categories: plugin_repo,security,performance,general
+          ignore-warnings: false
+          ignore-errors: false

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -15,8 +15,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Composer dependencies
+        run: composer install --no-dev --optimize-autoloader
+
       - uses: wordpress/plugin-check-action@v1
+        id: plugin-check
         with:
           categories: plugin_repo,security,performance,general
           ignore-warnings: false
           ignore-errors: false
+
+      - name: Plugin Check Summary
+        if: always()
+        run: |
+          RESULTS_FILE="${RUNNER_TEMP}/plugin-check-results.txt"
+          echo "## WordPress Plugin Check Results" >> $GITHUB_STEP_SUMMARY
+          if [ -s "$RESULTS_FILE" ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat "$RESULTS_FILE" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No results file found or file is empty." >> $GITHUB_STEP_SUMMARY
+            echo "Check the annotations on the Files Changed tab for details." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: wordpress/plugin-check-action@v1
         id: plugin-check
         with:
-          categories: plugin_repo,security,performance
+          categories: plugin_repo,security,performance,general
           exclude-directories: |
             tests
             bin
@@ -34,8 +34,10 @@ jobs:
             WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
             WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
             WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+            WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
             WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-          include-experimental: false
+            WordPress.WP.EnqueuedResourceParameters.MissingVersion
+          include-experimental: true
 
       - name: Plugin Check Summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+##### [Version 0.13.10](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.9...v0.13.10) (2024-03-26)
+
+### Improvements
+- Updated internal dependencies
+- Improved readme to link to the public source files
+- Filter promotions
+
 ##### [Version 0.13.9](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.8...v0.13.9) (2024-02-23)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 0.13.18](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.17...v0.13.18) (2025-05-23)
+
+- Updated dependencies
+
 ##### [Version 0.13.17](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.16...v0.13.17) (2025-04-17)
 
 - Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##### [Version 0.13.12](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.11...v0.13.12) (2024-04-01)
+
+### Improvements
+- **Updated internal dependencies**
+
 ##### [Version 0.13.11](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.10...v0.13.11) (2024-03-29)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 0.13.17](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.16...v0.13.17) (2025-04-17)
+
+- Updated dependencies
+
 ##### [Version 0.13.16](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.15...v0.13.16) (2024-11-07)
 
 - Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+##### [Version 0.13.11](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.10...v0.13.11) (2024-03-29)
+
+### Fixes
+- Updated internal dependencies
+- Enhanced security
+
 ##### [Version 0.13.10](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.9...v0.13.10) (2024-03-26)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##### [Version 0.13.13](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.12...v0.13.13) (2024-04-18)
+
+### Improvements
+​- **Updated internal dependencies:​​** Enhanced performance and security.
+
 ##### [Version 0.13.12](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.11...v0.13.12) (2024-04-01)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 0.13.14](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.13...v0.13.14) (2024-05-14)
+
+- Enhanced security
+
 ##### [Version 0.13.13](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.12...v0.13.13) (2024-04-18)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 0.13.19](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.18...v0.13.19) (2025-09-05)
+
+- Updated dependencies
+
 ##### [Version 0.13.18](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.17...v0.13.18) (2025-05-23)
 
 - Updated dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 0.13.21](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.20...v0.13.21) (2026-02-03)
+
+- Enhanced security
+
 ##### [Version 0.13.20](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.19...v0.13.20) (2025-12-15)
 
 - Fixed compatibility with PHP 8.1+ versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##### [Version 0.13.15](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.14...v0.13.15) (2024-07-10)
+
+- Removed recommendations of unsupported plugins
+- Fixed conditions for theme recommendation
+
 ##### [Version 0.13.14](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.13...v0.13.14) (2024-05-14)
 
 - Enhanced security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##### [Version 0.13.16](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.15...v0.13.16) (2024-11-07)
+
+- Updated dependencies
+
 ##### [Version 0.13.15](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.14...v0.13.15) (2024-07-10)
 
 - Removed recommendations of unsupported plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+##### [Version 0.13.20](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.19...v0.13.20) (2025-12-15)
+
+- Fixed compatibility with PHP 8.1+ versions
+- Updated dependencies
+
 ##### [Version 0.13.19](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.18...v0.13.19) (2025-09-05)
 
 - Updated dependencies

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.13
+ * Version:     0.13.14
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.13';
+	const VERSION = '0.13.14';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.12
+ * Version:     0.13.13
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.12';
+	const VERSION = '0.13.13';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.11
+ * Version:     0.13.12
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.11';
+	const VERSION = '0.13.12';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.16
+ * Version:     0.13.17
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.16';
+	const VERSION = '0.13.17';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.10
+ * Version:     0.13.11
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.10';
+	const VERSION = '0.13.11';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.18
+ * Version:     0.13.19
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.18';
+	const VERSION = '0.13.19';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.9
+ * Version:     0.13.10
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.9';
+	const VERSION = '0.13.10';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.15
+ * Version:     0.13.16
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.15';
+	const VERSION = '0.13.16';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.14
+ * Version:     0.13.15
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.14';
+	const VERSION = '0.13.15';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.19
+ * Version:     0.13.20
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.19';
+	const VERSION = '0.13.20';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.20
+ * Version:     0.13.21
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.20';
+	const VERSION = '0.13.21';
 
 	/**
 	 * Holds plugin data

--- a/menu-icons.php
+++ b/menu-icons.php
@@ -11,7 +11,7 @@
  * Plugin name: Menu Icons
  * Plugin URI:  https://github.com/Codeinwp/wp-menu-icons
  * Description: Spice up your navigation menus with pretty icons, easily.
- * Version:     0.13.17
+ * Version:     0.13.18
  * Author:      ThemeIsle
  * Author URI:  https://themeisle.com
  * License:     GPLv2
@@ -29,7 +29,7 @@ final class Menu_Icons {
 
 	const DISMISS_NOTICE = 'menu-icons-dismiss-notice';
 
-	const VERSION = '0.13.17';
+	const VERSION = '0.13.18';
 
 	/**
 	 * Holds plugin data

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.19",
+  "version": "0.13.20",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.14",
+  "version": "0.13.15",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.17",
+  "version": "0.13.18",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.13",
+  "version": "0.13.14",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.16",
+  "version": "0.13.17",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.15",
+  "version": "0.13.16",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.9",
+  "version": "0.13.10",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.18",
+  "version": "0.13.19",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "menu-icons",
   "title": "Menu Icons",
   "description": "Spice up your navigation menus with pretty icons, easily.",
-  "version": "0.13.11",
+  "version": "0.13.12",
   "homepage": "http://wordpress.org/plugins/menu-icons/",
   "license": "GPL-2.0",
   "author": {

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,14 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.12](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.11...v0.13.12) (2024-04-01)
+
+### Improvements
+- **Updated internal dependencies**
+
+
+
+
 ##### [Version 0.13.11](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.10...v0.13.11) (2024-03-29)
 
 ### Fixes

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,13 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.18](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.17...v0.13.18) (2025-05-23)
+
+- Updated dependencies
+
+
+
+
 ##### [Version 0.13.17](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.16...v0.13.17) (2025-04-17)
 
 - Updated dependencies

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,13 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.14](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.13...v0.13.14) (2024-05-14)
+
+- Enhanced security
+
+
+
+
 ##### [Version 0.13.13](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.12...v0.13.13) (2024-04-18)
 
 ### Improvements

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,16 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.10](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.9...v0.13.10) (2024-03-26)
+
+### Improvements
+- Updated internal dependencies
+- Improved readme to link to the public source files
+- Filter promotions
+
+
+
+
 ##### [Version 0.13.9](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.8...v0.13.9) (2024-02-23)
 
 ### Fixes

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,15 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.11](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.10...v0.13.11) (2024-03-29)
+
+### Fixes
+- Updated internal dependencies
+- Enhanced security
+
+
+
+
 ##### [Version 0.13.10](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.9...v0.13.10) (2024-03-26)
 
 ### Improvements

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: codeinwp, themeisle
 Tags: menu, nav-menu, icons, navigation
 Requires at least: 4.7
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,13 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.17](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.16...v0.13.17) (2025-04-17)
+
+- Updated dependencies
+
+
+
+
 ##### [Version 0.13.16](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.15...v0.13.16) (2024-11-07)
 
 - Updated dependencies

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,13 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.19](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.18...v0.13.19) (2025-09-05)
+
+- Updated dependencies
+
+
+
+
 ##### [Version 0.13.18](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.17...v0.13.18) (2025-05-23)
 
 - Updated dependencies

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,14 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.20](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.19...v0.13.20) (2025-12-15)
+
+- Fixed compatibility with PHP 8.1+ versions
+- Updated dependencies
+
+
+
+
 ##### [Version 0.13.19](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.18...v0.13.19) (2025-09-05)
 
 - Updated dependencies

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: codeinwp, themeisle
 Tags: menu, nav-menu, icons, navigation
 Requires at least: 4.7
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: codeinwp, themeisle
 Tags: menu, nav-menu, icons, navigation
 Requires at least: 4.7
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,14 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.13](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.12...v0.13.13) (2024-04-18)
+
+### Improvements
+​- **Updated internal dependencies:​​** Enhanced performance and security.
+
+
+
+
 ##### [Version 0.13.12](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.11...v0.13.12) (2024-04-01)
 
 ### Improvements

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,13 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.21](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.20...v0.13.21) (2026-02-03)
+
+- Enhanced security
+
+
+
+
 ##### [Version 0.13.20](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.19...v0.13.20) (2025-12-15)
 
 - Fixed compatibility with PHP 8.1+ versions

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: codeinwp, themeisle
 Tags: menu, nav-menu, icons, navigation
 Requires at least: 4.7
-Tested up to: 6.5
+Tested up to: 6.6
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: codeinwp, themeisle
 Tags: menu, nav-menu, icons, navigation
 Requires at least: 4.7
-Tested up to: 6.8
+Tested up to: 6.9
 Stable tag: trunk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,14 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.15](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.14...v0.13.15) (2024-07-10)
+
+- Removed recommendations of unsupported plugins
+- Fixed conditions for theme recommendation
+
+
+
+
 ##### [Version 0.13.14](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.13...v0.13.14) (2024-05-14)
 
 - Enhanced security

--- a/readme.txt
+++ b/readme.txt
@@ -222,6 +222,13 @@ Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
 == Changelog ==
 
+##### [Version 0.13.16](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.15...v0.13.16) (2024-11-07)
+
+- Updated dependencies
+
+
+
+
 ##### [Version 0.13.15](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.14...v0.13.15) (2024-07-10)
 
 - Removed recommendations of unsupported plugins

--- a/readme.txt
+++ b/readme.txt
@@ -220,6 +220,11 @@ add_filter( 'menu_icons_menu_settings', 'my_menu_icons_menu_settings', 10, 2 );
 = I can't select a custom image size from the *Image Size* dropdown =
 Read [this blog post](http://kucrut.org/add-custom-image-sizes-right-way/).
 
+= How to report a security issue? =
+ 
+Plugin security is a core priority for us. If you identify a potential vulnerability, we ask that you disclose it responsibly.
+Please follow the reporting protocols outlined on our [Security Page](https://themeisle.com/security/).
+
 == Changelog ==
 
 ##### [Version 0.13.21](https://github.com/codeinwp/wp-menu-icons/compare/v0.13.20...v0.13.21) (2026-02-03)


### PR DESCRIPTION
Adds automated wordpress.org guideline checks on every PR using the official wordpress/plugin-check-action.

This check is **non-blocking** — it will report issues as annotations on the PR but won't prevent merging.

Categories checked: plugin_repo, security, performance, general.