### PR TITLE
Restored svg menu icon size and styles

### DIFF
--- a/includes/front.php
+++ b/includes/front.php
@@ -483,10 +483,10 @@ final class Menu_Icons_Front_End {
 			}
 		}
 		if ( ! empty( $width ) ) {
-			$width = sprintf( ' width="%d"', $width );
+			$width = sprintf( ' width="%d"', esc_attr( $width ) );
 		}
 		if ( ! empty( $height ) ) {
-			$height = sprintf( ' height="%d"', $height );
+			$height = sprintf( ' height="%d"', esc_attr( $height ) );
 		}
 		$image_alt = get_post_meta( $meta['icon'], '_wp_attachment_image_alt', true );
 		$image_alt = $image_alt ? wp_strip_all_tags( $image_alt ) : '';
@@ -495,9 +495,9 @@ final class Menu_Icons_Front_End {
 			esc_url( wp_get_attachment_url( $meta['icon'] ) ),
 			esc_attr( $classes ),
 			esc_attr( $image_alt ),
-			esc_attr( $width ),
-			esc_attr( $height ),
-			esc_attr( $style )
+			$width,
+			$height,
+			$style
 		);
 	}
 


### PR DESCRIPTION
### Summary
Escaped the width and height of the SVG icon.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/wp-menu-icons/issues/333