### PR TITLE
Fixed vertical alignment in flex layouts

### DIFF
--- a/includes/front.php
+++ b/includes/front.php
@@ -339,6 +339,18 @@ final class Menu_Icons_Front_End {
 
 			$rule = self::$default_style[ $key ];
 
+			// Special handling for vertical-align because it affects the layout of flex containers.
+			if ( 'vertical_align' === $key ) {
+				$stored = isset( $meta[ $key ] ) ? $meta[ $key ] : $rule['value'];
+
+				if ( $stored !== $rule['value'] ) {
+					$style_a[ $rule['property'] ] = $stored;
+				}
+
+				$style_a['align-self'] = self::calculate_align_self( $stored );
+				continue;
+			}
+
 			if ( ! isset( $meta[ $key ] ) || $meta[ $key ] === $rule['value'] ) {
 				continue;
 			}
@@ -355,13 +367,13 @@ final class Menu_Icons_Front_End {
 			return $style_s;
 		}
 
-		foreach ( $style_a as $key => $value ) {
-			$style_s .= "{$key}:{$value};";
+		foreach ( $style_a as $prop => $value ) {
+			$style_s .= "{$prop}:{$value};";
 		}
 
 		$style_s = esc_attr( $style_s );
 
-		if ( $as_attribute  ) {
+		if ( $as_attribute ) {
 			$style_s = sprintf( ' style="%s"', $style_s );
 		}
 
@@ -512,5 +524,22 @@ final class Menu_Icons_Front_End {
 	public static function _add_menu_item_class( $classes, $item, $args ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 		$classes[] = 'menu-item';
 		return $classes;
+	}
+
+	/**
+	 * Calculate align-self value.
+	 *
+	 * @param string $value vertical-align value.
+	 * @return string
+	 */
+	private static function calculate_align_self( $value ) {
+		$align_self_map = array(
+			'top'      => 'flex-start',
+			'middle'   => 'center',
+			'bottom'   => 'flex-end',
+			'baseline' => 'baseline',
+		);
+
+		return isset( $align_self_map[ $value ] ) ? $align_self_map[ $value ] : 'center';
 	}
 }

--- a/includes/front.php
+++ b/includes/front.php
@@ -51,6 +51,19 @@ final class Menu_Icons_Front_End {
 	 */
 	protected static $hidden_label_class = 'visuallyhidden';
 
+	/**
+	 * Align-self map for vertical-align values.
+	 *
+	 * @access private
+	 * @var    array
+	 */
+	private static $align_self_map = array(
+		'top'      => 'flex-start',
+		'middle'   => 'center',
+		'bottom'   => 'flex-end',
+		'baseline' => 'baseline',
+	);
+
 
 	/**
 	 * Add hooks for front-end functionalities
@@ -341,13 +354,13 @@ final class Menu_Icons_Front_End {
 
 			// Special handling for vertical-align because it affects the layout of flex containers.
 			if ( 'vertical_align' === $key ) {
-				$stored = isset( $meta[ $key ] ) ? $meta[ $key ] : $rule['value'];
-
-				if ( $stored !== $rule['value'] ) {
-					$style_a[ $rule['property'] ] = $stored;
+				if ( ! isset( $meta[ $key ] ) || $meta[ $key ] === $rule['value'] ) {
+					continue;
 				}
 
-				$style_a['align-self'] = self::calculate_align_self( $stored );
+				$stored                       = $meta[ $key ];
+				$style_a[ $rule['property'] ] = $stored;
+				$style_a['align-self']        = isset( self::$align_self_map[ $stored ] ) ? self::$align_self_map[ $stored ] : 'center';
 				continue;
 			}
 
@@ -524,22 +537,5 @@ final class Menu_Icons_Front_End {
 	public static function _add_menu_item_class( $classes, $item, $args ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 		$classes[] = 'menu-item';
 		return $classes;
-	}
-
-	/**
-	 * Calculate align-self value.
-	 *
-	 * @param string $value vertical-align value.
-	 * @return string
-	 */
-	private static function calculate_align_self( $value ) {
-		$align_self_map = array(
-			'top'      => 'flex-start',
-			'middle'   => 'center',
-			'bottom'   => 'flex-end',
-			'baseline' => 'baseline',
-		);
-
-		return isset( $align_self_map[ $value ] ) ? $align_self_map[ $value ] : 'center';
 	}
 }

--- a/includes/meta.php
+++ b/includes/meta.php
@@ -103,6 +103,14 @@ final class Menu_Icons_Meta {
 			$value['position'] = $defaults['position'];
 		}
 
+		// Backward-compatibility: values removed in favour of align-self support.
+		$supported_vertical_align = array( 'top', 'middle', 'bottom', 'baseline' );
+		if ( isset( $value['vertical_align'] ) &&
+			! in_array( $value['vertical_align'], $supported_vertical_align, true )
+		) {
+			$value['vertical_align'] = 'middle';
+		}
+
 		if ( isset( $value['size'] ) && ! isset( $value['font_size'] ) ) {
 			$value['font_size'] = $value['size'];
 			unset( $value['size'] );

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -536,16 +536,8 @@ final class Menu_Icons_Settings {
 				'default' => 'middle',
 				'choices' => array(
 					array(
-						'value' => 'super',
-						'label' => __( 'Super', 'menu-icons' ),
-					),
-					array(
 						'value' => 'top',
 						'label' => __( 'Top', 'menu-icons' ),
-					),
-					array(
-						'value' => 'text-top',
-						'label' => __( 'Text Top', 'menu-icons' ),
 					),
 					array(
 						'value' => 'middle',
@@ -556,16 +548,8 @@ final class Menu_Icons_Settings {
 						'label' => __( 'Baseline', 'menu-icons' ),
 					),
 					array(
-						'value' => 'text-bottom',
-						'label' => __( 'Text Bottom', 'menu-icons' ),
-					),
-					array(
 						'value' => 'bottom',
 						'label' => __( 'Bottom', 'menu-icons' ),
-					),
-					array(
-						'value' => 'sub',
-						'label' => __( 'Sub', 'menu-icons' ),
 					),
 				),
 			),


### PR DESCRIPTION
### Summary
Handled vertical alignment for elements inside flex containers by using `align-self` instead of `vertical-align`, which is not supported in flex layouts.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/wp-menu-icons/issues/271